### PR TITLE
proxy_space: play, stop and clear proxies in 'p'

### DIFF
--- a/lua/scnvim/_extensions/fzf-sc/finders.lua
+++ b/lua/scnvim/_extensions/fzf-sc/finders.lua
@@ -78,14 +78,14 @@ function M.postinfo_controlspecs()
 end
 
 -- Nodeproxy
-function M.stop_nodeproxy()
+function M.stop_ndef()
 	local sc_code = [[Ndef.all['localhost'].monitors.asArray.sort]]
 	local supercollider_return_code = "%s.stop;"
 
 	utils.fzf_sc_eval(sc_code, supercollider_return_code)
 end
 
-function M.play_nodeproxy()
+function M.play_ndef()
 	local sc_code = [[Ndef.all['localhost'].existingProxies.asArray.sort]]
 	local supercollider_return_code = "Ndef('%s').play;"
 
@@ -102,6 +102,28 @@ end
 function M.ndef_gui()
 	local sc_code = [[Ndef.all['localhost'].existingProxies.asArray.sort]]
 	local supercollider_return_code = "Ndef('%s').gui();"
+
+	utils.fzf_sc_eval(sc_code, supercollider_return_code)
+end
+
+-- ProxySpace
+function M.stop_proxy()
+	local sc_code = [[p.playingProxies.asArray.sort]]
+	local supercollider_return_code = "p['%s'].stop"
+
+	utils.fzf_sc_eval(sc_code, supercollider_return_code)
+end
+
+function M.play_proxy()
+	local sc_code = [[p.activeProxies.asArray.reject {|it| p[it].isMonitoring }.sort]]
+	local supercollider_return_code = "p['%s'].play"
+
+	utils.fzf_sc_eval(sc_code, supercollider_return_code)
+end
+
+function M.clear_proxy()
+	local sc_code = [[(p.krProxyNames ++ p.arProxyNames).asArray.sort]]
+	local supercollider_return_code = "p['%s'].clear(1)"
 
 	utils.fzf_sc_eval(sc_code, supercollider_return_code)
 end

--- a/lua/scnvim/_extensions/fzf-sc/finders.lua
+++ b/lua/scnvim/_extensions/fzf-sc/finders.lua
@@ -47,6 +47,7 @@ controlNames.do{|ctrl, index|
 These are the arguments for SynthDef: " ++ synthName.asString ++ "\n\n").postln;
 outString.postln;
 }.value();
+"".postln;
 ]]
 
 	utils.fzf_sc_eval(sc_code, supercollider_return_code)


### PR DESCRIPTION
Maybe this is not of general interest because it depends on a `ProxySpace` called `p`. On the other hand `p` is commonly used as global variable to put a `ProxySpace` in to. As in most of the examples in the Help System.
It also changes the names of ´nodeproxy_play´ and siblings, to ´ndef_play´, etc. I found it more descriptive and difficult to be confounded with the ones I inserted.